### PR TITLE
Add script to fetch challenge participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # Memory-of-the-World-challenge
-points calculation for the Memory of the World challenge in Wikipedia
+
+Points calculation for the Memory of the World challenge in Wikipedia.
+
+## Setup
+
+Create and activate a virtual environment, then install the required
+packages:
+
+```
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Utilities
+
+`load_participants.py` uses [Pywikibot](https://www.mediawiki.org/wiki/Manual:Pywikibot) to
+retrieve usernames listed on the challenge participants page.  By
+default it prints the usernames, but an output file can be specified.
+The `--wikis` option queries each user's global account to display the
+Wikipedia projects where they have edited the article namespace within
+the last 32 days. Other Wikimedia projects are ignored.
+
+```
+python load_participants.py
+python load_participants.py --wikis
+python load_participants.py --wikis --output participants.txt
+```
+
+Use the `--login` option if the page requires authentication.

--- a/load_participants.py
+++ b/load_participants.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Fetch challenge participants from Wikimedia and display or save them.
+
+This script uses Pywikibot to read the usernames listed on the
+"Memory of the World challenge" participants page.  Usernames can be
+printed to standard output or written to a file.  Login is optional for
+public pages but can be requested for private pages.
+"""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+
+import pywikibot
+
+
+def extract_usernames(page: pywikibot.Page) -> List[str]:
+    """Return a sorted list of usernames linked on *page*.
+
+    The function inspects user-page links and templates such as
+    ``{{User|Example}}`` to collect participant names.
+    """
+    usernames: Set[str] = set()
+
+    # Links to user pages
+    for link in page.linkedPages():
+        if link.namespace() == 2:  # User namespace
+            usernames.add(link.title(with_ns=False))
+
+    # ``{{User|Example}}`` templates
+    for template, params in page.templatesWithParams():
+        if template.title(with_ns=False).lower() == "user" and params:
+            usernames.add(params[0].strip())
+
+    return sorted(usernames)
+
+
+def write_output(lines: Iterable[str], output: Path | None) -> None:
+    """Write *lines* either to stdout or to *output* file."""
+    if output is None:
+        for line in lines:
+            print(line)
+    else:
+        output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+RECENT_DAYS = 32
+
+
+def fetch_user_wikis(
+    site: pywikibot.Site, usernames: Iterable[str]
+) -> Dict[str, List[str]]:
+    """Return a mapping of username to active Wikipedia projects.
+
+    A wiki is included only if the user has edited its main namespace within
+    the last :data:`RECENT_DAYS` days.
+    """
+
+    result: Dict[str, List[str]] = {}
+    now = datetime.now(timezone.utc)
+    recent = timedelta(days=RECENT_DAYS)
+
+    for name in usernames:
+        request = site._simple_request(
+            action="query",
+            meta="globaluserinfo",
+            guiuser=name,
+            guiprop="merged",
+        )
+        data = request.submit()
+        wikis: List[str] = []
+        for merged in data["query"]["globaluserinfo"].get("merged", []):
+            if merged.get("editcount", 0) == 0 or "wikipedia.org" not in merged.get("url", ""):
+                continue
+            dbname = merged["wiki"]
+            local = pywikibot.Site.fromDBName(dbname)
+            try:
+                contribs = list(local.usercontribs(user=name, namespaces=[0], total=1))
+            except Exception:
+                continue
+            if not contribs:
+                continue
+            ts = contribs[0]["timestamp"]
+            if isinstance(ts, str):
+                ts = pywikibot.Timestamp.fromISOformat(ts)
+            if now - ts <= recent:
+                wikis.append(dbname)
+        result[name] = wikis
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Load usernames from the Memory of the World challenge participants page"
+        )
+    )
+    parser.add_argument(
+        "-o", "--output", type=Path, help="write the usernames to this file"
+    )
+    parser.add_argument(
+        "--login", action="store_true", help="log in before reading the page"
+    )
+    parser.add_argument(
+        "--page",
+        default="Memory_of_the_World_challenge_2025/Participants",
+        help="title of the participants page",
+    )
+    parser.add_argument(
+        "--wikis",
+        action="store_true",
+        help="also fetch the Wikipedia projects each user has edited",
+    )
+    args = parser.parse_args()
+
+    site = pywikibot.Site("meta", "meta")
+    if args.login:
+        site.login()
+
+    page = pywikibot.Page(site, args.page)
+    try:
+        usernames = extract_usernames(page)
+    except pywikibot.exceptions.APIError as e:  # login required
+        if e.code in {"readapidenied", "permissiondenied"}:
+            pywikibot.error(
+                "Login is required to read this page. Use --login with valid credentials."
+            )
+            return 1
+        raise
+
+    if args.wikis:
+        wiki_map = fetch_user_wikis(site, usernames)
+        lines = [f"{user}: {', '.join(wiki_map[user])}" for user in usernames]
+        write_output(lines, args.output)
+    else:
+        write_output(usernames, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pywikibot


### PR DESCRIPTION
## Summary
- add `--wikis` option to `load_participants.py` to list wikipedias each participant has edited using the MediaWiki `globaluserinfo` API
- document how to fetch participant wikis in the README
- only include wikis where a user edited the article namespace within the last 32 days

## Testing
- `python -m py_compile load_participants.py`
- `python -m pip install -r requirements.txt --quiet`
- `python load_participants.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68c68fe4a1a4832e8651bf8ec0ee1610