### PR TITLE
List UNESCO-linked pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,15 @@ retrieve usernames listed on the challenge participants page.  By
 default it prints the usernames, but an output file can be specified.
 The `--wikis` option queries each user's global account to display the
 Wikipedia projects where they have at least one edit. Other Wikimedia
-projects are ignored.
+projects are ignored.  Adding `--unesco` lists the articles on those
+projects that link to the UNESCO "Memory of the World" website, including
+localized links such as `https://www.unesco.org/en/memory-world`.
 
 ```
 python load_participants.py
 python load_participants.py --wikis
 python load_participants.py --wikis --output participants.txt
+python load_participants.py --wikis --unesco
 ```
 
 Use the `--login` option if the page requires authentication.

--- a/load_participants.py
+++ b/load_participants.py
@@ -4,7 +4,10 @@
 This script uses Pywikibot to read the usernames listed on the
 "Memory of the World challenge" participants page.  Usernames can be
 printed to standard output or written to a file.  Login is optional for
-public pages but can be requested for private pages.
+public pages but can be requested for private pages.  With the
+``--wikis`` option the script also lists Wikipedia projects each user
+edited recently, and ``--unesco`` reports which pages on those wikis
+link to UNESCO's "Memory of the World" website.
 """
 from __future__ import annotations
 
@@ -86,6 +89,33 @@ def fetch_user_wikis(
     return result
 
 
+
+def fetch_unesco_pages(wikis: Iterable[str]) -> Dict[str, List[str]]:
+    """Return pages that link to the UNESCO Memory of the World site.
+
+    *wikis* should be an iterable of database names such as ``"enwiki"``.
+    For each wiki the function queries ``exturlusage`` and collects titles
+    of pages that contain links whose URL includes ``memory-world`` either
+    directly or with a language code such as ``/en/memory-world``.  The
+    returned mapping uses the wiki database name as the key and a sorted
+    list of page titles as the value.
+    """
+
+    # UNESCO publishes the Memory of the World site in these languages
+    languages = ['', 'ar', 'en', 'es', 'fr', 'ru', 'zh']
+
+    result: Dict[str, List[str]] = {}
+    for wiki in wikis:
+        wiki_site = pywikibot.site.APISite.fromDBName(wiki)
+        pages: Set[str] = set()
+        for lang in languages:
+            suffix = f'/{lang}/memory-world' if lang else '/memory-world'
+            query = f'www.unesco.org{suffix}'
+            for page in wiki_site.exturlusage(query, protocol='https'):
+                pages.add(page.title())
+        result[wiki] = sorted(pages)
+    return result
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -108,6 +138,11 @@ def main() -> int:
         action="store_true",
         help="also fetch Wikipedia projects each user edited in the last 32 days",
     )
+    parser.add_argument(
+        "--unesco",
+        action="store_true",
+        help="list pages on those wikis that link to the UNESCO Memory of the World site",
+    )
     args = parser.parse_args()
 
     site = pywikibot.Site("meta", "meta")
@@ -128,6 +163,17 @@ def main() -> int:
     if args.wikis:
         wiki_map = fetch_user_wikis(site, usernames)
         lines = [f"{user}: {', '.join(wiki_map[user])}" for user in usernames]
+
+        if args.unesco:
+            all_wikis = sorted({w for wikis in wiki_map.values() for w in wikis})
+            unesco_map = fetch_unesco_pages(all_wikis)
+            lines.append("")
+            lines.append("Pages linking to UNESCO Memory of the World:")
+            for wiki in all_wikis:
+                pages = unesco_map.get(wiki, [])
+                listing = ", ".join(pages) if pages else "(none)"
+                lines.append(f"{wiki}: {listing}")
+
         write_output(lines, args.output)
     else:
         write_output(usernames, args.output)


### PR DESCRIPTION
## Summary
- add `--unesco` option to list articles linking to UNESCO "Memory of the World" site
- extend matching to include localized links like `https://www.unesco.org/en/memory-world`
- document localized link support in README

## Testing
- `python -m py_compile load_participants.py`
- `python load_participants.py --help`
- `timeout 10 python load_participants.py --wikis --unesco` *(fails: HTTPSConnectionPool(... 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68c6a223308c832e91f42344b4482578