### PR TITLE
Fix revision retrieval for UNESCO edit check

### DIFF
--- a/challenge/management/commands/check_unesco_edits.py
+++ b/challenge/management/commands/check_unesco_edits.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
 
                     page_obj = pywikibot.Page(site, contrib["title"])
                     revid = contrib["revid"]
-                    revision = next(page_obj.revisions(revids=[revid], content=True))
+                    revision = page_obj.get_revision(revid, content=True)
                     parentid = revision.parentid
                     new_text = revision.text or ""
                     old_text = page_obj.getOldVersion(parentid) if parentid else ""


### PR DESCRIPTION
## Summary
- Replace deprecated `page.revisions` call with `get_revision` to fetch content by revision ID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7d9a458832e8a3fd61b77c9102d