### PR TITLE
Document statistics update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ pip install -r requirements.txt
 python manage.py migrate
 ```
 
+Create a `user-config.py` file so Pywikibot can log in to the Wikimedia
+projects.
+
 ## Utilities
 
 The `load_participants` management command uses
@@ -59,3 +62,19 @@ python manage.py load_participants --wikis --unesco
 ```
 
 Use the `--login` option if the page requires authentication.
+
+## Updating statistics
+
+To refresh the set of participant wikis and publish updated statistics:
+
+```bash
+python manage.py load_participants --wikis
+python manage.py check_unesco_edits
+```
+
+Run `check_unesco_edits` with `--dry-run` to display the results locally
+without writing them to the wiki:
+
+```bash
+python manage.py check_unesco_edits --dry-run
+```


### PR DESCRIPTION
## Summary
- clarify that Pywikibot requires a `user-config.py` for login
- document how to refresh participant wikis and update on-wiki statistics, including `--dry-run`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check_unesco_edits --dry-run` *(fails: ProxyError: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c78f297cec832e980cd2c4dae22e7c